### PR TITLE
Updated KnitwearLitInput.hlsl to zero initialize outSurfaceData.

### DIFF
--- a/Assets/Knitwear Shader/Shaders/KnitwearLitInput.hlsl
+++ b/Assets/Knitwear Shader/Shaders/KnitwearLitInput.hlsl
@@ -112,6 +112,8 @@ half3 SampleKnitwear(float2 uv, float2 dpdx, float2 dpdy)
 
 inline void InitializeKnitwearLitSurfaceData(float2 uv, out SurfaceData outSurfaceData)
 {
+    
+	ZERO_INITIALIZE(SurfaceData, outSurfaceData); 
     float2 texCoord = uv;
 
     float2 dtdx = ddx(uv);


### PR DESCRIPTION
My local Unity version is 2020.3.21f1, but I didn't want to upgrade your repo to a new version just for an .hlsl patch.
I made the change, pushed to github, and then upgraded and verified it worked in 2020.3.21f1. It should work in your version as well, but let me know if you want me to push the upgraded version too.

The .hlsl now compiles without errors and the sample scene works well. Thanks for this repo! I actually own the Blender shader version, and am impressed you translated it to Unity. 